### PR TITLE
Default value for empty values on paginated request

### DIFF
--- a/src/main/scala/com/codacy/client/bitbucket/client/BitbucketClient.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/client/BitbucketClient.scala
@@ -26,7 +26,7 @@ class BitbucketClient(key: String, secretKey: String, token: String, secretToken
   }
 
   /*
-   * Does an paginated API request and parses the json output into a sequence of classes
+   * Does a paginated API request and parses the json output into a sequence of classes
    */
   def executePaginated[T](request: Request[Seq[T]])(implicit reader: Reads[T]): RequestResponse[Seq[T]] = {
     get(request.url) match {
@@ -37,7 +37,8 @@ class BitbucketClient(key: String, secretKey: String, token: String, secretToken
             executePaginated(Request(nextUrl, request.classType)).value.getOrElse(Seq())
         }.getOrElse(Seq())
 
-        RequestResponse(Some((json \ "values").as[Seq[T]] ++ nextRepos))
+        val values = (json \ "values").asOpt[Seq[T]].getOrElse(Seq())
+        RequestResponse(Some(values ++ nextRepos))
 
       case Left(error) =>
         RequestResponse[Seq[T]](None, error.detail, hasError = true)


### PR DESCRIPTION
```
play.api.libs.json.JsResultException: JsResultException(errors:List(((0)/parents//hash,List(ValidationError(error.path.result.multiple,WrappedArray())))))
        at play.api.libs.json.JsValue$$anonfun$2.apply(JsValue.scala:67)
        at play.api.libs.json.JsValue$$anonfun$2.apply(JsValue.scala:67)
        at play.api.libs.json.JsResult$class.fold(JsResult.scala:77)
        at play.api.libs.json.JsError.fold(JsResult.scala:13)
        at play.api.libs.json.JsValue$class.as(JsValue.scala:65)
        at play.api.libs.json.JsArray.as(JsValue.scala:125)
        at com.codacy.client.bitbucket.client.BitbucketClient.executePaginated(BitbucketClient.scala:40)
        at com.codacy.client.bitbucket.service.PullRequestServices.getPullRequestCommits(PullRequestServices.scala:28)
```