### PR TITLE
Add comments on changesets and PR endpoints

### DIFF
--- a/src/main/scala/com/codacy/client/bitbucket/PullRequestComment.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/PullRequestComment.scala
@@ -1,0 +1,20 @@
+package com.codacy.client.bitbucket
+
+import org.joda.time.DateTime
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+case class PullRequestComment(id: Long, username: String, display_name: String, content: String, created_on: DateTime)
+
+object PullRequestComment {
+  val dateFormat = "yyyy-MM-dd HH:mm:ssZZ"
+  implicit val jodaDateTimeReads = Reads.jodaDateReads(dateFormat)
+
+  implicit val reader: Reads[PullRequestComment] = (
+    (__ \ "comment_id").read[Long] and
+      (__ \ "username").read[String] and
+      (__ \ "display_name").read[String] and
+      (__ \ "content").read[String] and
+      (__ \ "utc_created_on").read[DateTime]
+    )(PullRequestComment.apply _)
+}

--- a/src/main/scala/com/codacy/client/bitbucket/service/CommitServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/service/CommitServices.scala
@@ -1,7 +1,7 @@
 package com.codacy.client.bitbucket.service
 
-import com.codacy.client.bitbucket.CommitComment
 import com.codacy.client.bitbucket.client.{BitbucketClient, Request, RequestResponse}
+import com.codacy.client.bitbucket.{CommitComment, PullRequestComment}
 import play.api.libs.json.{JsNumber, JsObject, JsString}
 
 class CommitServices(client: BitbucketClient) {

--- a/src/main/scala/com/codacy/client/bitbucket/service/CommitServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/service/CommitServices.scala
@@ -2,16 +2,24 @@ package com.codacy.client.bitbucket.service
 
 import com.codacy.client.bitbucket.CommitComment
 import com.codacy.client.bitbucket.client.{BitbucketClient, Request, RequestResponse}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsNumber, JsObject, JsString}
 
 class CommitServices(client: BitbucketClient) {
 
-  def createComment(author: String, repo: String, commit: String, body: String): RequestResponse[CommitComment] = {
+  def createComment(author: String, repo: String, commit: String, body: String, file: Option[String] = None, line: Option[Int] = None): RequestResponse[CommitComment] = {
     val url = s"https://bitbucket.org/!api/1.0/repositories/$author/$repo/changesets/${commit.take(12)}/comments"
 
-    val values = Json.obj("content" -> body)
+    val params = file.map(filename => "filename" -> JsString(filename)) ++
+      line.map(lineTo => "line_to" -> JsNumber(lineTo))
+
+    val values = JsObject(params.toSeq :+ "content" -> JsString(body))
 
     client.post(Request(url, classOf[CommitComment]), values)
   }
 
+  def deleteComment(author: String, repo: String, commit: String, commentId: Long): Unit = {
+    val url = s"https://bitbucket.org/!api/1.0/repositories/$author/$repo/changesets/${commit.take(12)}/comments/$commentId"
+
+    client.delete(url)
+  }
 }


### PR DESCRIPTION
Added methods for commenting (and deleting comments) on changesets as described in:

* https://confluence.atlassian.com/bitbucket/changesets-resource-296095208.html#changesetsResource-POSTanewcommentonachangeset
* https://confluence.atlassian.com/bitbucket/changesets-resource-296095208.html#changesetsResource-DELETEacommentonachangeset
* https://confluence.atlassian.com/bitbucket/pullrequests-resource-1-0-296095210.html#pullrequestsResource1.0-POSTanewcomment
* https://confluence.atlassian.com/bitbucket/pullrequests-resource-1-0-296095210.html#pullrequestsResource1.0-DELETEapullrequestcomment