### PR TITLE
Basic auth support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 name := """bitbucket-scala-client"""
 
-version := "1.7.1-SNAPSHOT"
+version := "1.7.1-zamblauskas-bulk-hook-update-SNAPSHOT"
 
 scalaVersion := "2.10.5"
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 name := """bitbucket-scala-client"""
 
-version := "1.7.1-zamblauskas-bulk-hook-update-SNAPSHOT"
+version := "1.8.0-SNAPSHOT"
 
 scalaVersion := "2.10.5"
 

--- a/src/main/scala/com/codacy/client/bitbucket/client/Authentication.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/client/Authentication.scala
@@ -1,0 +1,44 @@
+package com.codacy.client.bitbucket.client
+
+import play.api.libs.oauth.{ConsumerKey, OAuthCalculator, RequestToken}
+import play.api.libs.ws.{WSAuthScheme, WSRequest}
+
+object Authentication {
+
+  sealed trait Credentials
+
+  case class OAuthCredentials(key: String, secretKey: String, token: String, secretToken: String) extends Credentials
+
+  case class BasicAuthCredentials(username: String, password: String) extends Credentials
+
+
+  sealed trait Authenticator {
+    def authenticate(req: WSRequest): WSRequest
+  }
+
+  object Authenticator {
+    def fromCredentials(credentials: Credentials): Authenticator =  {
+      credentials match {
+        case c: OAuthCredentials     => new OAuthAuthenticator(c)
+        case c: BasicAuthCredentials => new BasicAuthAuthenticator(c)
+      }
+    }
+  }
+
+  class OAuthAuthenticator(credentials: OAuthCredentials) extends Authenticator {
+    private lazy val KEY = ConsumerKey(credentials.key, credentials.secretKey)
+    private lazy val TOKEN = RequestToken(credentials.token, credentials.secretToken)
+
+    private lazy val requestSigner = OAuthCalculator(KEY, TOKEN)
+
+    def authenticate(req: WSRequest): WSRequest = req.sign(requestSigner)
+  }
+
+  class BasicAuthAuthenticator(credentials: BasicAuthCredentials) extends Authenticator {
+    def authenticate(req: WSRequest): WSRequest = req.withAuth(credentials.username, credentials.password, WSAuthScheme.BASIC)
+  }
+
+  implicit class WsRequestExtensions(val req: WSRequest) extends AnyVal {
+    def authenticate(authenticator: Authenticator): WSRequest = authenticator.authenticate(req)
+  }
+}

--- a/src/main/scala/com/codacy/client/bitbucket/client/Authentication.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/client/Authentication.scala
@@ -3,12 +3,21 @@ package com.codacy.client.bitbucket.client
 import play.api.libs.oauth.{ConsumerKey, OAuthCalculator, RequestToken}
 import play.api.libs.ws.{WSAuthScheme, WSRequest}
 
+/**
+  * Handles request authentication.
+  * Provides several different authentication options.
+  *
+  * @author - Robertas Zamblauskas
+  */
 object Authentication {
 
   sealed trait Credentials
 
   case class OAuthCredentials(key: String, secretKey: String, token: String, secretToken: String) extends Credentials
 
+  /**
+    * Your username and password | app password.
+    */
   case class BasicAuthCredentials(username: String, password: String) extends Credentials
 
 
@@ -38,6 +47,9 @@ object Authentication {
     def authenticate(req: WSRequest): WSRequest = req.withAuth(credentials.username, credentials.password, WSAuthScheme.BASIC)
   }
 
+  /**
+    * Provide nicer syntax for authentication.
+    */
   implicit class WsRequestExtensions(val req: WSRequest) extends AnyVal {
     def authenticate(authenticator: Authenticator): WSRequest = authenticator.authenticate(req)
   }

--- a/src/main/scala/com/codacy/client/bitbucket/service/BuildStatusServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/service/BuildStatusServices.scala
@@ -11,7 +11,7 @@ class BuildStatusServices(client: BitbucketClient) {
    *
    */
   def getBuildStatus(owner: String, repository: String, commit: String, key: String): RequestResponse[BuildStatus] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/commit/$commit/statuses/build/$key"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/commit/$commit/statuses/build/$key"
 
     client.execute(Request(url, classOf[BuildStatus]))
   }
@@ -22,7 +22,7 @@ class BuildStatusServices(client: BitbucketClient) {
    *
    */
   def createBuildStatus(owner: String, repository: String, commit: String, buildStatus: BuildStatus): RequestResponse[BuildStatus] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/commit/$commit/statuses/build"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/commit/$commit/statuses/build"
 
     val values = Map("state" -> Seq(buildStatus.state.toString), "key" -> Seq(buildStatus.key),
       "name" -> Seq(buildStatus.name), "url" -> Seq(buildStatus.url),
@@ -36,7 +36,7 @@ class BuildStatusServices(client: BitbucketClient) {
  *
  */
   def updateBuildStatus(owner: String, repository: String, commit: String, buildStatus: BuildStatus): RequestResponse[BuildStatus] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/commit/$commit/statuses/build/${buildStatus.key}"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/commit/$commit/statuses/build/${buildStatus.key}"
 
     val payload = Json.obj(
       "state" -> buildStatus.state,

--- a/src/main/scala/com/codacy/client/bitbucket/service/CommitServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/service/CommitServices.scala
@@ -8,7 +8,7 @@ import play.api.libs.json.{JsNumber, JsObject, JsString}
 class CommitServices(client: BitbucketClient) {
 
   def createComment(author: String, repo: String, commit: String, body: String, file: Option[String] = None, line: Option[Int] = None): RequestResponse[CommitComment] = {
-    val url = s"https://bitbucket.org/!api/1.0/repositories/$author/$repo/changesets/${CommitHelper.anchor(commit)}/comments"
+    val url = s"https://bitbucket.org/api/1.0/repositories/$author/$repo/changesets/${CommitHelper.anchor(commit)}/comments"
 
     val params = file.map(filename => "filename" -> JsString(filename)) ++
       line.map(lineTo => "line_to" -> JsNumber(lineTo))
@@ -19,7 +19,7 @@ class CommitServices(client: BitbucketClient) {
   }
 
   def deleteComment(author: String, repo: String, commit: String, commentId: Long): Unit = {
-    val url = s"https://bitbucket.org/!api/1.0/repositories/$author/$repo/changesets/${CommitHelper.anchor(commit)}/comments/$commentId"
+    val url = s"https://bitbucket.org/api/1.0/repositories/$author/$repo/changesets/${CommitHelper.anchor(commit)}/comments/$commentId"
 
     client.delete(url)
   }

--- a/src/main/scala/com/codacy/client/bitbucket/service/HookServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/service/HookServices.scala
@@ -19,8 +19,19 @@ class HookServices(client: BitbucketClient) {
       "url"         -> hookUrl,
       "events"      -> events
     )
-    
     client.postJson(Request(servicesUrl, classOf[Webhook]), payload)
+  }
+
+  def update(author: String, repo: String, uuid: String,
+    active: Boolean, description: String, hookUrl: String, events:Set[String]): RequestResponse[Webhook] = {
+    val servicesUrl = getServicesUrl(author, repo)
+    val payload = Json.obj(
+      "active"      -> active,
+      "description" -> description,
+      "url"         -> hookUrl,
+      "events"      -> events
+    )
+    client.putJson(Request(s"$servicesUrl/$uuid", classOf[Webhook]), payload)
   }
 
   def delete(author: String, repo: String, uuid: String): RequestResponse[Boolean] = {

--- a/src/main/scala/com/codacy/client/bitbucket/service/PullRequestServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/service/PullRequestServices.scala
@@ -14,7 +14,7 @@ class PullRequestServices(client: BitbucketClient) {
    *
    */
   def getPullRequests(owner: String, repository: String, states: Seq[String] = Seq("OPEN")): RequestResponse[Seq[PullRequest]] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/pullrequests?pagelen=50&state=${states.mkString("&state=")}"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/pullrequests?pagelen=50&state=${states.mkString("&state=")}"
 
     client.executePaginated(Request(url, classOf[Seq[PullRequest]]))
   }
@@ -24,13 +24,13 @@ class PullRequestServices(client: BitbucketClient) {
    *
    */
   def getPullRequestCommits(owner: String, repository: String, prId: Long): RequestResponse[Seq[SimpleCommit]] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/pullrequests/$prId/commits?pagelen=100"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/pullrequests/$prId/commits?pagelen=100"
 
     client.executePaginated(Request(url, classOf[Seq[SimpleCommit]]))
   }
 
   def create(owner: String, repository: String, title: String, sourceBranch: String, destinationBranch: String): RequestResponse[JsObject] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/pullrequests"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/pullrequests"
 
     val payload = Json.obj(
       "title" -> title,
@@ -50,22 +50,22 @@ class PullRequestServices(client: BitbucketClient) {
   }
 
   def postApprove(owner: String, repository: String, prId: Long): RequestResponse[JsObject] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/pullrequests/$prId/approve"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/pullrequests/$prId/approve"
     client.postJson(Request(url, classOf[JsObject]), JsNull)
   }
 
   def deleteApprove(owner: String, repository: String, prId: Long): RequestResponse[Boolean] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/pullrequests/$prId/approve"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/pullrequests/$prId/approve"
     client.delete(url)
   }
 
   def merge(owner: String, repository: String, prId: Long): RequestResponse[JsObject] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/pullrequests/$prId/merge"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/pullrequests/$prId/merge"
     client.postJson(Request(url, classOf[JsObject]), JsNull)
   }
 
   def decline(owner: String, repository: String, prId: Long): RequestResponse[JsObject] = {
-    val url = s"https://bitbucket.org/!api/2.0/repositories/$owner/$repository/pullrequests/$prId/decline"
+    val url = s"https://bitbucket.org/api/2.0/repositories/$owner/$repository/pullrequests/$prId/decline"
     client.postJson(Request(url, classOf[JsObject]), JsNull)
   }
 
@@ -95,7 +95,7 @@ class PullRequestServices(client: BitbucketClient) {
   }
 
   def listComments(author: String, repo: String, pullRequestId: Int): RequestResponse[Seq[SimplePullRequestComment]] = {
-    val url = s"https://bitbucket.org/!api/1.0/repositories/$author/$repo/pullrequests/$pullRequestId/comments"
+    val url = s"https://bitbucket.org/api/1.0/repositories/$author/$repo/pullrequests/$pullRequestId/comments"
 
     client.execute(Request(url, classOf[Seq[SimplePullRequestComment]]))
   }

--- a/src/main/scala/com/codacy/client/bitbucket/service/RepositoryServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/service/RepositoryServices.scala
@@ -11,7 +11,7 @@ class RepositoryServices(client: BitbucketClient) {
    * Use this if you're looking for a full list of all of the repositories associated with a user
    */
   def getRepositories: RequestResponse[Seq[SimpleRepository]] = {
-    client.execute(Request(s"https://bitbucket.org/!api/1.0/user/repositories", classOf[Seq[SimpleRepository]]))
+    client.execute(Request(s"https://bitbucket.org/api/1.0/user/repositories", classOf[Seq[SimpleRepository]]))
   }
 
   /*
@@ -19,14 +19,14 @@ class RepositoryServices(client: BitbucketClient) {
    * if the caller is authenticated and is authorized to view the repository.
    */
   def getRepositories(username: String): RequestResponse[Seq[Repository]] = {
-    client.executePaginated(Request(s"https://bitbucket.org/!api/2.0/repositories/$username", classOf[Seq[Repository]]))
+    client.executePaginated(Request(s"https://bitbucket.org/api/2.0/repositories/$username", classOf[Seq[Repository]]))
   }
 
   /*
    * Creates a ssh key
    */
   def createKey(username: String, repo: String, key: String): RequestResponse[SshKey] = {
-    val url = s"https://bitbucket.org/!api/1.0/repositories/$username/$repo/deploy-keys"
+    val url = s"https://bitbucket.org/api/1.0/repositories/$username/$repo/deploy-keys"
 
     val values = Json.obj(
       "key" -> key,

--- a/src/main/scala/com/codacy/client/bitbucket/service/UserServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/service/UserServices.scala
@@ -10,21 +10,21 @@ class UserServices(client: BitbucketClient) {
    * Gets the basic information associated with the token owner account.
    */
   def getUser: RequestResponse[User] = {
-    client.execute(Request("https://bitbucket.org/!api/1.0/user", classOf[User]))
+    client.execute(Request("https://bitbucket.org/api/1.0/user", classOf[User]))
   }
 
   /*
    * Gets the basic information associated with an account.
    */
   def getUser(username: String): RequestResponse[User] = {
-    client.execute(Request(s"https://bitbucket.org/!api/1.0/users/$username", classOf[User]))
+    client.execute(Request(s"https://bitbucket.org/api/1.0/users/$username", classOf[User]))
   }
 
   /*
    * Creates a ssh key
    */
   def createKey(username: String, key: String): RequestResponse[SshKey] = {
-    val url = s"https://bitbucket.org/!api/1.0/users/$username/ssh-keys"
+    val url = s"https://bitbucket.org/api/1.0/users/$username/ssh-keys"
 
     val values = Json.obj(
       "key" -> key,


### PR DESCRIPTION
This PR adds support for Basic Auth, i.e. username and password or app password.
Using the client now is as simple as:
```scala
import com.codacy.client.bitbucket.client.Authentication._
import com.codacy.client.bitbucket.client._
import com.codacy.client.bitbucket.service._

val client = new BitbucketClient(BasicAuthCredentials(username = "XXX", password = "YYY"))
val userService = new UserServices(client)
println(userService.getUser)
```

Major changes are:
- introduction of `Authentication.scala` with support for OAuth and Basic Auth
- removed '!' mark from all URLs
- added `HookServices#update`

Wrt to testing - done some manual testing with both authentication methods - seems to work fine. Don't see what unit tests could be added - no logic here.

Bumped the version to 1.8.0 since it's a braking change on the `BitbucketClient` contructor params.