### PR TITLE
Add endpoint to refresh the access_token

### DIFF
--- a/src/main/scala/com/codacy/client/bitbucket/v2/AccessToken.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/v2/AccessToken.scala
@@ -1,0 +1,13 @@
+package com.codacy.client.bitbucket.v2
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Reads, __}
+
+case class AccessToken(access_token: String, refresh_token: String)
+
+object AccessToken {
+  implicit val reader: Reads[AccessToken] = (
+    (__ \ "access_token").read[String] and
+      (__ \ "refresh_token").read[String]
+  )(AccessToken.apply _)
+}

--- a/src/main/scala/com/codacy/client/bitbucket/v2/Authorization.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/v2/Authorization.scala
@@ -1,0 +1,23 @@
+package com.codacy.client.bitbucket.v2
+
+import play.api.libs.json.{Json, Writes}
+
+object Authorization {
+
+  sealed trait RefreshCredentials
+
+  case class RefreshToken(refresh_token: String) extends RefreshCredentials {
+    val grant_type = "refresh_token"
+  }
+
+  object RefreshToken {
+    implicit val writer: Writes[RefreshToken] = Json.writes[RefreshToken]
+  }
+
+  object RefreshCredentials {
+    implicit val writer: Writes[RefreshCredentials] =
+      Writes[RefreshCredentials] {
+        case c: RefreshToken => Json.toJson(c)(RefreshToken.writer)
+      }
+  }
+}

--- a/src/main/scala/com/codacy/client/bitbucket/v2/service/AuthorizationServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/v2/service/AuthorizationServices.scala
@@ -1,0 +1,22 @@
+package com.codacy.client.bitbucket.v2.service
+
+import com.codacy.client.bitbucket.client.{BitbucketClient, Request, RequestResponse}
+import com.codacy.client.bitbucket.v2.AccessToken
+import com.codacy.client.bitbucket.v2.Authorization.RefreshCredentials
+import play.api.libs.json._
+
+class AuthorizationServices(client: BitbucketClient) {
+
+  /*
+   * Gets new AccessToken with the RefreshCredentials
+   *
+   */
+  def refreshAccessToken(
+      credentials: RefreshCredentials): RequestResponse[AccessToken] = {
+    val url = s"https://bitbucket.org/site/oauth2/access_token"
+
+    val values = Json.toJson[RefreshCredentials](credentials)
+
+    client.postJson(Request(url, classOf[AccessToken]), values)
+  }
+}


### PR DESCRIPTION
Since on OAuth2 the access_token can expire, there is a new endpoint for refreshing it that was missing in the library.