### PR TITLE
fix: Fix compilation caching in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ workflows:
             bash <(curl -Ls https://coverage.codacy.com/get.sh) report --skip
           requires:
             - populate_cache_compile
-            - check_format
       - codacy/tag_version:
           name: tag_version
           context: CodacyAWS
           requires:
+            - check_format
             - test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
       - codacy/sbt:
           name: populate_cache_compile
           persist_to_workspace: true
-          cmd: sbt +test:compile
+          cmd: sbt coverage +test:compile
           requires:
             - codacy/checkout_and_version
       - codacy/sbt:


### PR DESCRIPTION
`coverage` changes the compilation classpath invalidating the compiled files.
This PR enables coverage in `test:compile` so we it reuses the result later.
It runs in parallel `check_format` and `test` too.