### PR TITLE
feature: Use Bearer token instead of sending the access_token on the URL

### DIFF
--- a/src/main/play_json_2.4/com/codacy/client/bitbucket/WSWrapper.scala
+++ b/src/main/play_json_2.4/com/codacy/client/bitbucket/WSWrapper.scala
@@ -7,8 +7,8 @@ object WSWrapper {
   type WSClient = play.api.libs.ws.WSClient
   type WSRequest = play.api.libs.ws.WSRequest
 
-  def withQueryString(request: WSRequest, parameters: (String, String)*): WSRequest = {
-    request.withQueryString(parameters: _*)
+  def withHttpHeaders(request: WSRequest, headers: (String, String)*): WSRequest = {
+    request.withHeaders(headers: _*)
   }
 
   def build(): WSClient = {

--- a/src/main/play_json_2.7/com/codacy/client/bitbucket/WSWrapper.scala
+++ b/src/main/play_json_2.7/com/codacy/client/bitbucket/WSWrapper.scala
@@ -4,8 +4,8 @@ object WSWrapper {
   type WSClient = play.api.libs.ws.StandaloneWSClient
   type WSRequest = play.api.libs.ws.StandaloneWSRequest
 
-  def withQueryString(request: WSRequest, parameters: (String, String)*): WSRequest = {
-    request.withQueryStringParameters(parameters: _*)
+  def withHttpHeaders(request: WSRequest, headers: (String, String)*): WSRequest = {
+    request.withHttpHeaders(headers: _*)
   }
 
   def build(materializer: akka.stream.Materializer): WSClient = {

--- a/src/main/scala/com/codacy/client/bitbucket/client/Authentication.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/client/Authentication.scala
@@ -36,8 +36,9 @@ object Authentication {
   }
 
   class OAuth2Authenticator(credentials: OAuth2Credentials) extends Authenticator {
-    override def authenticate(req: WSRequest): WSRequest =
-      WSWrapper.withQueryString(req, "access_token" -> credentials.accessToken)
+    override def authenticate(req: WSRequest): WSRequest = {
+      WSWrapper.withHttpHeaders(req, ("Authorization", s"Bearer ${credentials.accessToken}"))
+    }
   }
 
   class BasicAuthAuthenticator(credentials: BasicAuthCredentials) extends Authenticator {


### PR DESCRIPTION
This now reflects the most desired way of authenticated requests as stated at:
https://developer.atlassian.com/bitbucket/api/2/reference/meta/authentication#make-requests

And also avoid problems where bitbucket returns all the parameters on its "next" field on responses