### PR TITLE
clean: Parameterize WSClient to avoid creating one client for each request [CY-2322]

### DIFF
--- a/src/main/play_json_2.4/com/codacy/client/bitbucket/client/BitbucketClient.scala
+++ b/src/main/play_json_2.4/com/codacy/client/bitbucket/client/BitbucketClient.scala
@@ -4,8 +4,5 @@ import com.codacy.client.bitbucket.WSWrapper
 import com.codacy.client.bitbucket.WSWrapper.WSClient
 import com.codacy.client.bitbucket.client.Authentication.Credentials
 
-import scala.util.Try
-
-class BitbucketClient(credentials: Credentials) extends BitbucketClientBase(credentials) {
-  override protected def buildClient(): WSClient = WSWrapper.build()
-}
+class BitbucketClient(client: WSClient = WSWrapper.build(), credentials: Credentials)
+    extends BitbucketClientBase(client, credentials)

--- a/src/main/play_json_2.7/com/codacy/client/bitbucket/client/BitbucketClient.scala
+++ b/src/main/play_json_2.7/com/codacy/client/bitbucket/client/BitbucketClient.scala
@@ -5,6 +5,7 @@ import com.codacy.client.bitbucket.WSWrapper
 import com.codacy.client.bitbucket.WSWrapper.WSClient
 import com.codacy.client.bitbucket.client.Authentication.Credentials
 
-class BitbucketClient(credentials: Credentials, materializer: Materializer) extends BitbucketClientBase(credentials) {
-  override protected def buildClient(): WSClient = WSWrapper.build(materializer)
-}
+class BitbucketClient(materializer: Materializer)(
+    client: WSClient = WSWrapper.build(materializer),
+    credentials: Credentials
+) extends BitbucketClientBase(client, credentials)

--- a/src/main/scala/com/codacy/client/bitbucket/client/BitbucketClientBase.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/client/BitbucketClientBase.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.util.{Failure, Properties, Success, Try}
 
-abstract class BitbucketClientBase(credentials: Credentials) {
+abstract class BitbucketClientBase(client: WSClient, credentials: Credentials) {
 
   val apiBaseUrl = "https://bitbucket.org/api/2.0"
   val userBaseUrl = s"$apiBaseUrl/user"
@@ -26,8 +26,6 @@ abstract class BitbucketClientBase(credentials: Credentials) {
   private lazy val requestTimeout = Duration(10, SECONDS)
 
   private lazy val authenticator = Authenticator.fromCredentials(credentials)
-
-  protected def buildClient(): WSClient
 
   /**
     * Does an API request and parses the json output into a class.
@@ -243,7 +241,7 @@ abstract class BitbucketClientBase(credentials: Credentials) {
   }
 
   private def withClientEither[T](block: WSClient => Either[ResponseError, T]): Either[ResponseError, T] = {
-    withClient(block) match {
+    Try(block(client)) match {
       case Success(res) => res
       case Failure(error) =>
         Left(ResponseError("Request failed", getFullStackTrace(error), error.getMessage))
@@ -251,7 +249,7 @@ abstract class BitbucketClientBase(credentials: Credentials) {
   }
 
   private def withClientRequest[T](block: WSClient => RequestResponse[T]): RequestResponse[T] = {
-    withClient(block) match {
+    Try(block(client)) match {
       case Success(res) => res
       case Failure(error) =>
         val statusMessage =
@@ -262,13 +260,6 @@ abstract class BitbucketClientBase(credentials: Credentials) {
           """.stripMargin
         FailedResponse(statusMessage)
     }
-  }
-
-  private def withClient[T](block: WSClient => T): Try[T] = {
-    val client: WSClient = buildClient()
-    val result = Try(block(client))
-    client.close()
-    result
   }
 
   private def getFullStackTrace(throwableOpt: Throwable, accumulator: String = ""): String = {

--- a/src/main/scala/com/codacy/client/bitbucket/client/BitbucketClientBase.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/client/BitbucketClientBase.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.util.{Failure, Properties, Success, Try}
 
-abstract class BitbucketClientBase(client: WSClient, credentials: Credentials) {
+abstract class BitbucketClientBase(val client: WSClient, credentials: Credentials) {
 
   val apiBaseUrl = "https://bitbucket.org/api/2.0"
   val userBaseUrl = s"$apiBaseUrl/user"


### PR DESCRIPTION
The decision to put the default client is cool for usability but might lead people to use it without closing the client.
What do you think about this?

I think I saw a way to run code before a class is collected but I might be dreaming since cannot find it.