### PR TITLE
fix: Timeout while fetching workspace permissions CY-2356

### DIFF
--- a/src/main/scala/com/codacy/client/bitbucket/v2/service/WorkspaceServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/v2/service/WorkspaceServices.scala
@@ -30,21 +30,13 @@ class WorkspaceServices(client: BitbucketClient) {
     * Retrieve the permissions for all workspaces matching the supplied username.
     *
     * @param username The username or the UUID of the account surrounded by curly-braces
-    * @param pageRequest The pagination request with cursor information
+    * @param pageRequest The pagination request with cursor information.
     * @return A [[RequestResponse]] with the user permissions for each workspace
     */
-  def getWorkspacePermissions(
-      username: String,
-      pageRequest: Option[PageRequest] = None
-  ): RequestResponse[Seq[WorkspacePermission]] = {
+  def getWorkspacePermissions(username: String, pageRequest: PageRequest): RequestResponse[Seq[WorkspacePermission]] = {
     val encodedUsername = URLEncoder.encode(username, "UTF-8")
     val baseRequestUrl = s"${client.workspacesBaseUrl}/$encodedUsername/permissions"
 
-    pageRequest match {
-      case Some(request) =>
-        client.executeWithCursor[WorkspacePermission](baseRequestUrl, request)
-      case None =>
-        client.executePaginated(Request(baseRequestUrl, classOf[Seq[WorkspacePermission]]))
-    }
+    client.executeWithCursor[WorkspacePermission](baseRequestUrl, pageRequest)
   }
 }


### PR DESCRIPTION
When passing None for the page request, we should avoid fetching all the pages because in some cases it can lead to a timeout on RPS and we also take the risk of being rate limited due to the number of calls we do to bitbucket. 
I already checked and we don't need all the pages on RPS since we just need to see if the call is successful or not, because if it is, we assume the user is an admin since only the admin can call this endpoint.