### PR TITLE
fix: Encode the quotes and brackets of UUID for the query request

### DIFF
--- a/src/main/scala/com/codacy/client/bitbucket/v2/service/UserServices.scala
+++ b/src/main/scala/com/codacy/client/bitbucket/v2/service/UserServices.scala
@@ -33,7 +33,8 @@ class UserServices(client: BitbucketClient) {
     * returns the workspace and their effective role
     */
   def getWorkspaceMembership(workspaceUUID: String): RequestResponse[WorkspacePermission] = {
-    val workspaceQuery = s"""workspace.uuid="$workspaceUUID""""
+    val workspaceUUIDEncoded = URLEncoder.encode(s""""$workspaceUUID"""", "UTF-8")
+    val workspaceQuery = s"""workspace.uuid=$workspaceUUIDEncoded"""
 
     client.executeWithCursor[WorkspacePermission](
       s"""${client.userBaseUrl}/permissions/workspaces?q=$workspaceQuery""",


### PR DESCRIPTION
Example:
"{693d-aa12}" -> %22%7B693d-aa12%7D%22