### PR TITLE
Cross-compile against Play 2.9 for Scala 2.13 CY-7703

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,13 @@ scmInfo := Some(
 pgpPassphrase := Option(System.getenv("SONATYPE_GPG_PASSPHRASE"))
   .map(_.toCharArray)
 
-name := s"${name.value}_playjson${playJsonVersion.value.split('.').take(2).mkString}"
+def playSuffix(playJsonVersion: String): String =
+  if (playJsonVersion.startsWith("2.7.")) "27"
+  else if (playJsonVersion.startsWith("2.8.")) "28"
+  else if (playJsonVersion.startsWith("2.10.")) "29"
+  else sys.error("Missing play suffix. Add a mapping from this play-json version to its Play version.")
+
+name := s"${name.value}_playjson${playSuffix(playJsonVersion.value)}"
 
 /**
   * Given a command it creates an alias to run the command

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ val scalaVersions = Seq(scala212, scala213)
 
 val play27 = "2.7.4"
 val play28 = "2.8.2"
+val play29 = "2.10.7"
 
 lazy val playJsonVersion = settingKey[String]("The version of play-json used for building.")
 ThisBuild / playJsonVersion := play27
@@ -63,7 +64,7 @@ name := s"${name.value}_playjson${playJsonVersion.value.split('.').take(2).mkStr
   * (which is not an allowed sbt alias name)
   */
 def addCrossAlias(command: String) = {
-  val matrix = Seq(scala212 -> Seq(play27, play28), scala213 -> Seq(play28))
+  val matrix = Seq(scala212 -> Seq(play27, play28), scala213 -> Seq(play28, play29))
 
   addCommandAlias(
     s"cross${command.split(':').map(_.capitalize).mkString}",
@@ -85,4 +86,5 @@ addCrossAlias("compile")
 addCrossAlias("test:compile")
 addCrossAlias("test")
 addCrossAlias("publish")
+addCrossAlias("publishLocal")
 addCrossAlias("publishSigned")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,8 @@ object Dependencies {
 
   def playJson(playJsonVersion: String) = {
     val playwsVersion =
-      if (playJsonVersion.startsWith("2.8.")) "2.1.11"
+      if (playJsonVersion.startsWith("2.10.")) "2.2.11"
+      else if (playJsonVersion.startsWith("2.8.")) "2.1.11"
       else if (playJsonVersion.startsWith("2.7.")) "2.0.8"
       else sys.error("Missing play-ws version. Check the compatible version based on its pom")
     Seq(


### PR DESCRIPTION
## Summary
- Add `play29 = "2.10.7"` (play-json version for Play 2.9) to the build matrix, paired with Scala 2.13
- Add matching `play-ws-standalone` version (2.2.11) for the 2.10.x play-json line in `Dependencies.scala`
- Scala 2.12 stays on Play 2.7/2.8 only (Play 2.9 dropped 2.12 support)

## Test plan
- [x] `sbt crossCompile` passes for all 4 matrix combos (2.12/2.7, 2.12/2.8, 2.13/2.8, 2.13/2.9)
- [x] `sbt crossTest` passes for all 4 combos (20 tests, 0 failures)
- [x] `sbt scalafmtCheckAll` passes