### PR TITLE
ci: bump codacy/base orb to 13.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@12.2.0
+  codacy: codacy/base@13.3.0
 
 references:
   cache_prefix: &cache_prefix sbt-cache-20250206


### PR DESCRIPTION
Problem: this repo pins codacy/base@12.2.0 while the fleet is on 13.3.0.

Fix: bump to codacy/base@13.3.0. This repo passes no openjdk_version, so the
change is version alignment, not a build fix.